### PR TITLE
setup.py: bs4 -> beautifulsoup4, remove alias

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author='jarbasAI',
     author_email='jarbasai@mailfence.com',
     description='unnoficial erowid, psychonaut wiki and ask_the_caterpillar apis',
-    install_requires=["lxml", "bs4", "requests"]
+    install_requires=["lxml", "beautifulsoup4", "requests"]
 )


### PR DESCRIPTION
`setup.py` contained an alias for `beautifulsoup4`, named [`bs4`](https://pypi.org/project/bs4/). 

When packaging this library for nixpkgs, i ended up [patching this out](https://github.com/NixOS/nixpkgs/blob/8284fc30c84ea47e63209d1a892aca1dfcd6bdf3/pkgs/development/python-modules/pysychonaut/default.nix#L13), which seems to have been working fine for the past months. I thought it would be nice to upstream this, so here's the PR :)

Thank you for the amazing work on this library by the way, I use it quite a lot and I really love it.